### PR TITLE
Handle empty CNAME CAA records

### DIFF
--- a/test.js
+++ b/test.js
@@ -8,6 +8,8 @@ const assert = require("assert");
     const tests = [
       {promise: caa("silverwind.io"), expect: records => records.map(r => r.value).includes("letsencrypt.org")},
       {promise: caa("sub.silverwind.io"), expect: records => records.map(r => r.value).includes("letsencrypt.org")},
+      {promise: caa("30d.org"), expect: records => records.map(r => r.value).includes("test")},
+      {promise: caa("testing-not-default.30d.org"), expect: records => records.map(r => r.value).includes("test")},
       {promise: caa.matches("silverwind.io", "letsencrypt.org"), expect: true},
       {promise: caa.matches("sub.silverwind.io", "letsencrypt.org"), expect: true},
       {promise: caa.matches("caa-none.silverwind.io", "letsencrypt.org"), expect: false},
@@ -15,6 +17,7 @@ const assert = require("assert");
       {promise: caa.matches("caa-wild.silverwind.io", "letsencrypt.org"), expect: true},
       {promise: caa.matches("*.caa-wild.silverwind.io", "letsencrypt.org"), expect: false},
       {promise: caa.matches("sub.caa-wild.silverwind.io", "letsencrypt.org"), expect: true},
+      {promise: caa.matches("testing-not-default.30d.org", "letsencrypt.org"), expect: false},
     ];
 
     const results = await Promise.all(tests.map(test => test.promise));


### PR DESCRIPTION
Fixes #2 

A couple of notes:
  - I added a couple personal domains to the tests just to more easily demonstrate the problem and make sure my solution fixed them (if you run the tests against master they will fail, but against this branch they pass) however I cannot guarantee those are stable domains, so ideally the updated tests is not included as is.
- I'm not sure if this is an ideal solution in your eyes or not, I mostly wanted to make sure I understood what was going on, so feel free to disregard this PR if you have a better approach in mind :)

Thanks for creating this library BTW, it is _super_ useful since the default node.js dns resolver is a bit lacking!