### PR TITLE
Fix alias recursion - fixes #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,11 +128,11 @@ const resolve = async ({name, query, servers, port, recursions, retries, tries, 
         }
       }
     }
-    recursions -= 1;
   }
 
   // If X is not a top-level domain, then R(X) = R(P(X)
   if (!isTLD(name)) {
+    recursions -= 1;
     return await resolve({name: parent(name), query, servers, port, recursions, retries, tries, ignoreTLDs});
   } else {
     return [];

--- a/test.js
+++ b/test.js
@@ -15,6 +15,10 @@ const assert = require("assert");
       {promise: caa.matches("caa-wild.silverwind.io", "letsencrypt.org"), expect: true},
       {promise: caa.matches("*.caa-wild.silverwind.io", "letsencrypt.org"), expect: false},
       {promise: caa.matches("sub.caa-wild.silverwind.io", "letsencrypt.org"), expect: true},
+
+      {promise: caa("30d.org"), expect: records => records.map(r => r.value).includes("test")},
+      {promise: caa("testing-not-default.30d.org"), expect: records => records.map(r => r.value).includes("test")},
+      {promise: caa.matches("testing-not-default.30d.org", "letsencrypt.org"), expect: false},
     ];
 
     const results = await Promise.all(tests.map(test => test.promise));


### PR DESCRIPTION
Alternate and simpler fix for #2. Basically, all this changes is not use `alias` for subsequent calls but go to `parent(name)` instead. So this means that a CNAME pointing to another CNAME would not be followed any more which does strike me as odd, but it seems in line with the RFC.

@n-johnson does it look alright to you? Your provided test cases pass with it.