### PR TITLE
support using in ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import {getServers} from "node:dns";
 import {promisify} from "node:util";
 import dnsSocket from "dns-socket";
-import tlds from "tlds";
+import tlds from "tlds" with { type: 'json' };
 
 const defaults = {
   ignoreTLDs: false,


### PR DESCRIPTION
Node of some version requires hints to import JSON, otherwise you see

```
TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "file:///workspaces/domain-info/node_modules/tlds/index.json" needs an import attribute of type "json"
```

This just adds the attribute.  It should be fine for node>=18 as already specified.